### PR TITLE
bug: Increased Terms and Conditions opacity and Variable Name in example env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,5 +3,5 @@ NEXT_PUBLIC_FRONTEND_URL="http://localhost:3000"
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 NEXT_PUBLIC_SECRET=secret
-BASE_PATH="/portal"
+NEXT_PUBLIC_BASE_PATH="/portal"
 NEXTAUTH_URL=https://localhost:3000/portal/api/auth

--- a/src/components/JAF/SeasonDetails.tsx
+++ b/src/components/JAF/SeasonDetails.tsx
@@ -23,7 +23,7 @@ const SeasonDetails = ({
   useEffect(() => {
     axios.get(`${baseUrl}/api/v1/jaf`).then((res) => {
       res.data.seasons.map((season: any) => {
-        const seasonString = `${season.type} ${season.year}`
+        const seasonString = `${season.type} ${season.year}`;
         options.push({ value: season.id, label: seasonString });
       });
       setOptionsx(options);
@@ -52,7 +52,7 @@ const SeasonDetails = ({
       </Row>
       <Row>
         <div className="ml-auto mr-auto flex flex-col items-start gap-8 ">
-          <div className="flex flex-col items-center w-[100%] text-[1rem] gap-1 opacity-60">
+          <div className="flex flex-col items-center w-[100%] text-[1rem] gap-1 opacity-100">
             <div>Terms and Conditions</div>
             <div className=" opacity-50 text-[0.8rem]">
               {" "}
@@ -60,7 +60,7 @@ const SeasonDetails = ({
             </div>
           </div>
           <div>
-            <div className="flex flex-col gap-3  text-[0.8rem] opacity-50">
+            <div className="flex flex-col gap-3  text-[0.8rem] opacity-100">
               {TermsAndConditions.map((tc, index) => (
                 <div key={index} className="flex gap-3">
                   <span>{index + 1}&#46;</span>


### PR DESCRIPTION
1. Changed the opacity of the Terms and Conditions to 100% for good visibility as mentioned in issue.
2. Changed .env.example variable name (NEXT_PUBLIC_BASE_PATH) to match the one used in config.

![image](https://github.com/user-attachments/assets/6b35ce99-dace-4caf-8eec-2e6e5b8aa49f)
