### PR TITLE
Fix the headings of the Job Table in Recruiter View

### DIFF
--- a/src/app/(routes)/recruiter/jobs/page.tsx
+++ b/src/app/(routes)/recruiter/jobs/page.tsx
@@ -49,10 +49,10 @@ const JobPage = () => {
                   Current Status
                 </th>
                 <th scope="col" className="px-6 py-3">
-                  Season Year
+                  Season Type
                 </th>
                 <th scope="col" className="px-6 py-3">
-                  Season Type
+                  Season Year
                 </th>
                 <th scope="col" className="px-6 py-3">
                   Company Name


### PR DESCRIPTION
This PR fixes the headings of the Job Table in the Recruiter View.

Before Fix - 
![Screenshot from 2025-06-22 20-30-00](https://github.com/user-attachments/assets/674db021-6aee-4aed-adc8-8f5c64ccd73a)

After Fix - 
![Screenshot from 2025-06-22 20-43-32](https://github.com/user-attachments/assets/acaf2777-3a90-450c-aee2-7e527e4d877c)
